### PR TITLE
Create coin api endpoint to get least amount of coin count provided with a USD amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,200 @@
+## Default ignore rules for Visual Studio temporary files, build results, and
+## various Visual Studio extensions.
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+# Used by MonoDevelop/Xamarin Studio
+*.userprefs
+
+# Visual Studio cache files
+**/.vs/
+# files ending in .cache can be ignored but but keep track of directories ending in .cache
+*.[Cc]ache
+!*.[Cc]ache/
+
+# Folders containing build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Dd]ebugPS/
+[Rr]elease/
+[Rr]eleases/
+[Rr]eleasePS/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+**/TestResults/
+**/Temp/
+**/buildlogs/
+
+# Output from an ATL Project
+dlldata.c
+
+# Other miscellaneous build outputs
+ClientBin/
+node_modules/
+Generated_Code/
+*_i.c
+*_p.c
+*_i.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+*.mdb
+*.apk
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.pfx
+*.publishsettings
+*.codegen.cs
+
+# Click-Once directory
+publish/
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+*.pubxml
+*.publishproj
+
+# Microsoft Azure
+PublishScripts/
+csx/
+*.build.csdef
+ecf/
+rcf/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# DNX
+**/*project.lock.json
+**/project.lock.json
+artifacts/
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# JetBrains tools
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+*.dotCover
+# used by Rider
+.idea/
+*.sln.iml
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# NuGet
+*.nupkg
+**/packages/*
+# this is used an MSBuild target, not recovered by dotnet restore so keep it
+!**/packages/build/
+*.nuget.props
+*.nuget.targets
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version.
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+
+# SQL Server files
+*.mdf
+*.ldf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+
+# FAKE - F# Make
+.fake/
+
+.svn/

--- a/CoinApi/CoinApi.sln
+++ b/CoinApi/CoinApi.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34322.80
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoinApi", "CoinApi\CoinApi.csproj", "{29AA5361-41F7-452A-8D4E-226DDEE4A40C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29AA5361-41F7-452A-8D4E-226DDEE4A40C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29AA5361-41F7-452A-8D4E-226DDEE4A40C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29AA5361-41F7-452A-8D4E-226DDEE4A40C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29AA5361-41F7-452A-8D4E-226DDEE4A40C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {755BE6FC-D8C5-419E-BEFA-A0C00D240793}
+	EndGlobalSection
+EndGlobal

--- a/CoinApi/CoinApi/CoinApi.csproj
+++ b/CoinApi/CoinApi/CoinApi.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/CoinApi/CoinApi/CoinApi.http
+++ b/CoinApi/CoinApi/CoinApi.http
@@ -1,0 +1,6 @@
+@CoinApi_HostAddress = http://localhost:5295
+
+GET {{CoinApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/CoinApi/CoinApi/CoinApi.http
+++ b/CoinApi/CoinApi/CoinApi.http
@@ -1,6 +1,6 @@
 @CoinApi_HostAddress = http://localhost:5295
 
-GET {{CoinApi_HostAddress}}/weatherforecast/
+GET {{CoinApi_HostAddress}}/change/
 Accept: application/json
 
 ###

--- a/CoinApi/CoinApi/Controllers/ChangeController.cs
+++ b/CoinApi/CoinApi/Controllers/ChangeController.cs
@@ -1,0 +1,42 @@
+using CoinApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CoinApi.Controllers {
+    [ApiController]
+    [Route("[controller]")]
+    public class ChangeController : ControllerBase 
+    {
+        private readonly ICoinService _coinService;
+        private readonly ILogger<ChangeController> _logger;
+
+        public ChangeController(ILogger<ChangeController> logger, ICoinService coinService) {
+            _logger = logger;
+            _coinService = coinService;
+        }
+
+        /// <summary>
+        /// Get the amount of coins for a USD amount. Smallest amount
+        /// of coins possible.
+        /// </summary>
+        /// <param name="amount">the amout in USD</param>
+        /// <returns>a dictionary representing the amount of each
+        /// coin that equals the USD amount</returns>
+        [HttpGet(Name = "GetChange")]
+        public async Task<IActionResult> Get(decimal amount) {
+            try {
+                if (amount <= 0) {
+                    return BadRequest("Amount cannot be less than or equal to zero.");
+                }
+
+                var coinCount = _coinService.GetChange(amount);
+
+                return Ok(coinCount);
+            }
+            catch (Exception ex) {
+                _logger.LogError(ex, ex.Message);
+
+                return StatusCode(500, "Internal Server Error. Please try again later.");
+            }
+        }
+    }
+}

--- a/CoinApi/CoinApi/Program.cs
+++ b/CoinApi/CoinApi/Program.cs
@@ -1,0 +1,28 @@
+using CoinApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<ICoinService, CoinService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment()) {
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/CoinApi/CoinApi/Properties/launchSettings.json
+++ b/CoinApi/CoinApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51393",
+      "sslPort": 44354
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5295",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7003;http://localhost:5295",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/CoinApi/CoinApi/Services/CoinService.cs
+++ b/CoinApi/CoinApi/Services/CoinService.cs
@@ -1,0 +1,32 @@
+﻿namespace CoinApi.Services {
+
+    /// <summary>
+    /// Coin service to get coin amounts
+    /// </summary>
+    public class CoinService : ICoinService
+    {
+        private readonly decimal[] _coinValues = { 1.00m, 0.25m, 0.10m, 0.05m, 0.01m };
+        private readonly string[] _coinNames = { "dollar coin", "quarter", "dime", "nickel", "penny" };
+
+        /// <summary>
+        /// Get the amount of coins for a USD amount. Smallest amount
+        /// of coins possible.
+        /// </summary>
+        /// <param name="amount">the usd amount</param>
+        /// <returns>a dictionary representing the amount of each
+        /// coin that equals the USD amount</returns>
+        public Dictionary<string, int> GetChange(decimal amount) {
+            Dictionary<string, int> coinCount = new Dictionary<string, int>();
+                         
+            for (int i = 0; i < _coinValues.Length; i++) {
+                int numCoins = (int)(amount / _coinValues[i]);
+                if (numCoins > 0) {
+                    coinCount.Add(_coinNames[i], numCoins);
+                    amount -= numCoins * _coinValues[i];
+                }
+            }
+
+            return coinCount;
+        }
+    }
+}

--- a/CoinApi/CoinApi/Services/ICoinService.cs
+++ b/CoinApi/CoinApi/Services/ICoinService.cs
@@ -1,0 +1,13 @@
+﻿namespace CoinApi.Services {
+    public interface ICoinService 
+    {
+        /// <summary>
+        /// Get the amount of coins for a USD amount. Smallest amount
+        /// of coins possible.
+        /// </summary>
+        /// <param name="amount">the usd amount</param>
+        /// <returns>a dictionary representing the amount of each
+        /// coin that equals the USD amount</returns>
+        public Dictionary<string, int> GetChange(decimal amount);
+    }
+}

--- a/CoinApi/CoinApi/appsettings.Development.json
+++ b/CoinApi/CoinApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/CoinApi/CoinApi/appsettings.json
+++ b/CoinApi/CoinApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This API accepts an amount of money (USD) as input, and returns a set of coins that add up to that amount. The algorithm should optimize for the fewest number of coins.

The following coins are allowed - dollar coin, quarter, dime, nickel, and penny.